### PR TITLE
Feature/runtime interface selection

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -128,9 +128,9 @@ dependencies = [
 
 [[package]]
 name = "generic-array"
-version = "0.14.4"
+version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "501466ecc8a30d1d3b7fc9229b122b2ce8ed6e9d9223f1138d4babb253e51817"
+checksum = "fd48d33ec7f05fbfa152300fdad764757cbded343c1aa1cff2fbaf4134851803"
 dependencies = [
  "typenum",
  "version_check",
@@ -203,18 +203,18 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.34"
+version = "1.0.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f84e92c0f7c9d58328b85a78557813e4bd845130db68d7184635344399423b1"
+checksum = "c7342d5883fbccae1cc37a2353b09c87c9b0f3afd73f5fb9bba687a1f733b029"
 dependencies = [
  "unicode-xid",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.10"
+version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38bc8cc6a5f2e3655e0899c1b848643b2562f853f114bfec7be120678e3ace05"
+checksum = "47aa80447ce4daf1717500037052af176af5d38cc3e571d9ec1c7353fc10c87d"
 dependencies = [
  "proc-macro2",
 ]
@@ -247,15 +247,15 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.131"
+version = "1.0.133"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4ad69dfbd3e45369132cc64e6748c2d65cdfb001a2b1c232d128b4ad60561c1"
+checksum = "97565067517b60e2d1ea8b268e59ce036de907ac523ad83a0475da04e818989a"
 
 [[package]]
 name = "serde_derive"
-version = "1.0.131"
+version = "1.0.133"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b710a83c4e0dff6a3d511946b95274ad9ca9e5d3ae497b63fda866ac955358d2"
+checksum = "ed201699328568d8d08208fdd080e3ff594e6c422e438b6705905da01005d537"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -280,9 +280,9 @@ dependencies = [
 
 [[package]]
 name = "sha2"
-version = "0.10.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "900d964dd36bb15bcf2f2b35694c072feab74969a54f2bbeec7a2d725d2bdcb6"
+checksum = "99c3bd8169c58782adad9290a9af5939994036b76187f7b4f0e6de91dbbfc0ec"
 dependencies = [
  "cfg-if 1.0.0",
  "cpufeatures",
@@ -291,9 +291,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "1.0.82"
+version = "1.0.85"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8daf5dd0bb60cbd4137b1b587d2fc0ae729bc07cf01cd70b36a1ed5ade3b9d59"
+checksum = "a684ac3dcd8913827e18cd09a68384ee66c1de24157e3c556c9ab16d85695fb7"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -322,9 +322,9 @@ dependencies = [
 
 [[package]]
 name = "typenum"
-version = "1.14.0"
+version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b63708a265f51345575b27fe43f9500ad611579e764c79edbc2037b1121959ec"
+checksum = "dcf81ac59edc17cc8697ff311e8f5ef2d99fcbd9817b34cec66f90b6c3dfd987"
 
 [[package]]
 name = "unicode-xid"
@@ -340,9 +340,9 @@ checksum = "74c1aa4511c38276c548406f0b1f5f8b793f000cfb51e18f278a102abd057e81"
 
 [[package]]
 name = "version_check"
-version = "0.9.3"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fecdca9a5291cc2b8dcf7dc02453fee791a280f3743cb0905f8822ae463b3fe"
+checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
 name = "void"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,15 +9,11 @@ repository = "https://github.com/helium/ecc608-linux-rs"
 readme = "README.md"
 
 [dependencies]
-i2c-linux = {version = "0", optional = true }
-serialport = {version = "4", default-features = false, optional = true }
+i2c-linux = {version = "0" }
+serialport = {version = "4", default-features = false }
 sha2 = "0"
 bytes = "1"
 bitfield = "0"
 serde = "1"
 serde_derive = "1"
 thiserror = "1"
-
-[features]
-swi = ["serialport"]
-i2c = ["i2c-linux"]

--- a/src/command.rs
+++ b/src/command.rs
@@ -239,32 +239,19 @@ impl EccCommand {
         bytes.put_u16_le(crc(&bytes[1..]))
     }
 
-    pub fn duration(&self) -> Duration {
-        //TODO FIX!!
+    pub fn duration(&self, swi_interface: bool ) -> Duration {
         let micros = match self {
-            Self::Info => 5_000,
-            Self::GenKey { .. } => 85_000,
-            Self::Read { .. } => 8_000,
+            Self::Info => 500,
+            Self::Read { .. } => 800,
             Self::Write { .. } => 8_000,
             // ecc608b increases the default lock duration of 15_000 by about 30%
             Self::Lock { .. } => 19_500,
             Self::Nonce { .. } => 17_000,
-            Self::Sign { .. } => 80_000,
-            Self::Ecdh { .. } => 42_000,
             Self::Random => 15_000,
+            Self::GenKey { .. } => if swi_interface {85_000} else {59_000},
+            Self::Sign { .. } => if swi_interface {80_000} else {64_000},
+            Self::Ecdh { .. } => if swi_interface {42_000} else {28_000},
         };
-        // let micros = match self {
-        //     Self::Info => 500,
-        //     Self::GenKey { .. } => 59_000,
-        //     Self::Read { .. } => 800,
-        //     Self::Write { .. } => 8_000,
-        //     // ecc608b increases the default lock duration of 15_000 by about 30%
-        //     Self::Lock { .. } => 19_500,
-        //     Self::Nonce { .. } => 17_000,
-        //     Self::Sign { .. } => 64_000,
-        //     Self::Ecdh { .. } => 28_000,
-        //     Self::Random => 15_000,
-        // };
         Duration::from_micros(micros)
     }
 }

--- a/src/command.rs
+++ b/src/command.rs
@@ -241,30 +241,30 @@ impl EccCommand {
 
     pub fn duration(&self) -> Duration {
         //TODO FIX!!
-        // let micros = match self {
-        //     Self::Info => 5_000,
-        //     Self::GenKey { .. } => 85_000,
-        //     Self::Read { .. } => 8_000,
-        //     Self::Write { .. } => 8_000,
-        //     // ecc608b increases the default lock duration of 15_000 by about 30%
-        //     Self::Lock { .. } => 19_500,
-        //     Self::Nonce { .. } => 17_000,
-        //     Self::Sign { .. } => 80_000,
-        //     Self::Ecdh { .. } => 42_000,
-        //     Self::Random => 15_000,
-        // };
         let micros = match self {
-            Self::Info => 500,
-            Self::GenKey { .. } => 59_000,
-            Self::Read { .. } => 800,
+            Self::Info => 5_000,
+            Self::GenKey { .. } => 85_000,
+            Self::Read { .. } => 8_000,
             Self::Write { .. } => 8_000,
             // ecc608b increases the default lock duration of 15_000 by about 30%
             Self::Lock { .. } => 19_500,
             Self::Nonce { .. } => 17_000,
-            Self::Sign { .. } => 64_000,
-            Self::Ecdh { .. } => 28_000,
+            Self::Sign { .. } => 80_000,
+            Self::Ecdh { .. } => 42_000,
             Self::Random => 15_000,
         };
+        // let micros = match self {
+        //     Self::Info => 500,
+        //     Self::GenKey { .. } => 59_000,
+        //     Self::Read { .. } => 800,
+        //     Self::Write { .. } => 8_000,
+        //     // ecc608b increases the default lock duration of 15_000 by about 30%
+        //     Self::Lock { .. } => 19_500,
+        //     Self::Nonce { .. } => 17_000,
+        //     Self::Sign { .. } => 64_000,
+        //     Self::Ecdh { .. } => 28_000,
+        //     Self::Random => 15_000,
+        // };
         Duration::from_micros(micros)
     }
 }

--- a/src/command.rs
+++ b/src/command.rs
@@ -1,7 +1,7 @@
 use crate::{
     constants::{
-        ATCA_COMMAND_FLAG, ATCA_ECDH, ATCA_GENKEY, ATCA_INFO, ATCA_LOCK, ATCA_NONCE, ATCA_RANDOM,
-        ATCA_READ, ATCA_RSP_SIZE_MIN, ATCA_SIGN, ATCA_WRITE, CMD_STATUS_BYTE_COMM, CMD_STATUS_BYTE_ECC,
+        ATCA_ECDH, ATCA_GENKEY, ATCA_INFO, ATCA_LOCK, ATCA_NONCE, ATCA_RANDOM, ATCA_READ,
+        ATCA_RSP_SIZE_MIN, ATCA_SIGN, ATCA_WRITE, CMD_STATUS_BYTE_COMM, CMD_STATUS_BYTE_ECC,
         CMD_STATUS_BYTE_EXEC, CMD_STATUS_BYTE_PARSE, CMD_STATUS_BYTE_SELF_TEST,
         CMD_STATUS_BYTE_SUCCESS, CMD_STATUS_BYTE_WAKE_SUCCESS, CMD_STATUS_BYTE_WATCHDOG,
     },
@@ -182,7 +182,7 @@ impl EccCommand {
     }
 
     pub fn bytes_into(&self, bytes: &mut BytesMut) {
-        bytes.put_slice(&[ATCA_COMMAND_FLAG, 0x00]);
+        bytes.put_slice(&[0x00, 0x00]);
         match self {
             Self::Info => {
                 put_cmd!(bytes, ATCA_INFO, 0, 0);
@@ -240,20 +240,19 @@ impl EccCommand {
     }
 
     pub fn duration(&self) -> Duration {
-        #[cfg(feature = "swi")]
-        let micros = match self {
-            Self::Info => 5_000,
-            Self::GenKey { .. } => 85_000,
-            Self::Read { .. } => 8_000,
-            Self::Write { .. } => 8_000,
-            // ecc608b increases the default lock duration of 15_000 by about 30%
-            Self::Lock { .. } => 19_500,
-            Self::Nonce { .. } => 17_000,
-            Self::Sign { .. } => 80_000,
-            Self::Ecdh { .. } => 42_000,
-            Self::Random => 15_000,
-        };
-        #[cfg(feature = "i2c")]
+        //TODO FIX!!
+        // let micros = match self {
+        //     Self::Info => 5_000,
+        //     Self::GenKey { .. } => 85_000,
+        //     Self::Read { .. } => 8_000,
+        //     Self::Write { .. } => 8_000,
+        //     // ecc608b increases the default lock duration of 15_000 by about 30%
+        //     Self::Lock { .. } => 19_500,
+        //     Self::Nonce { .. } => 17_000,
+        //     Self::Sign { .. } => 80_000,
+        //     Self::Ecdh { .. } => 42_000,
+        //     Self::Random => 15_000,
+        // };
         let micros = match self {
             Self::Info => 500,
             Self::GenKey { .. } => 59_000,

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -15,6 +15,8 @@ pub(crate) const CMD_STATUS_BYTE_COMM: u8 = 0xFF;
 
 pub(crate) const ATCA_RSP_SIZE_MIN: u8 = 4;
 
+pub(crate) const ATCA_SWI_TRANSMIT_FLAG: u8 = 0x88;
+pub(crate) const ATCA_SWI_SLEEP_FLAG: u8 = 0xCC;
 pub(crate) const ATCA_SWI_COMMAND_FLAG: u8 = 0x77;
 pub(crate) const ATCA_I2C_COMMAND_FLAG: u8 = 0x03;
 pub(crate) const ATCA_INFO: u8 = 0x30;

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -2,10 +2,8 @@ use std::time::Duration;
 
 pub(crate) const WAKE_DELAY: Duration = Duration::from_micros(1500);
 
-#[cfg(feature = "i2c")]
-pub(crate) const ATCA_CMD_SIZE_MAX: u16 = 4*36 + 7; 
-#[cfg(feature = "swi")]
-pub(crate) const ATCA_CMD_SIZE_MAX: u16 = (4*36 + 7) * 8; // 8 times bigger to accomodate UART bytes = SWI bits
+pub(crate) const ATCA_I2C_CMD_SIZE_MAX: u16 = 4*36 + 7; 
+pub(crate) const ATCA_SWI_CMD_SIZE_MAX: u16 = (4*36 + 7) * 8; // 8 times bigger to accomodate UART bytes = SWI bits
 
 pub(crate) const CMD_STATUS_BYTE_SUCCESS: u8 = 0x00;
 pub(crate) const CMD_STATUS_BYTE_PARSE: u8 = 0x03;
@@ -18,10 +16,8 @@ pub(crate) const CMD_STATUS_BYTE_COMM: u8 = 0xFF;
 
 pub(crate) const ATCA_RSP_SIZE_MIN: u8 = 4;
 
-#[cfg(feature = "swi")]
-pub(crate) const ATCA_COMMAND_FLAG: u8 = 0x77;
-#[cfg(feature = "i2c")]
-pub(crate) const ATCA_COMMAND_FLAG: u8 = 0x03;
+pub(crate) const ATCA_SWI_COMMAND_FLAG: u8 = 0x77;
+pub(crate) const ATCA_I2C_COMMAND_FLAG: u8 = 0x03;
 pub(crate) const ATCA_INFO: u8 = 0x30;
 pub(crate) const ATCA_READ: u8 = 0x02;
 pub(crate) const ATCA_WRITE: u8 = 0x12;

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -2,8 +2,7 @@ use std::time::Duration;
 
 pub(crate) const WAKE_DELAY: Duration = Duration::from_micros(1500);
 
-pub(crate) const ATCA_I2C_CMD_SIZE_MAX: u16 = 4*36 + 7; 
-pub(crate) const ATCA_SWI_CMD_SIZE_MAX: u16 = (4*36 + 7) * 8; // 8 times bigger to accomodate UART bytes = SWI bits
+pub(crate) const ATCA_CMD_SIZE_MAX: u16 = 4*36 + 7; 
 
 pub(crate) const CMD_STATUS_BYTE_SUCCESS: u8 = 0x00;
 pub(crate) const CMD_STATUS_BYTE_PARSE: u8 = 0x03;

--- a/src/ecc.rs
+++ b/src/ecc.rs
@@ -1,4 +1,4 @@
-use crate::constants::{ ATCA_CMD_SIZE_MAX, ATCA_I2C_COMMAND_FLAG, ATCA_SWI_COMMAND_FLAG, WAKE_DELAY };
+use crate::constants::{ ATCA_CMD_SIZE_MAX, ATCA_I2C_COMMAND_FLAG, ATCA_SWI_COMMAND_FLAG };
 use crate::transport::{EccTransport, TransportProtocol};
 use crate::{
     command::{EccCommand, EccResponse},
@@ -186,8 +186,13 @@ impl Ecc {
                 TransportProtocol::I2c => {buf[0] = ATCA_I2C_COMMAND_FLAG}
                 TransportProtocol::Swi => {buf[0] = ATCA_SWI_COMMAND_FLAG}
             }
+
+            let delay = match self.transport.protocol {
+                TransportProtocol::I2c => {command.duration( false )}
+                TransportProtocol::Swi => {command.duration( true )}
+            };
             
-            if let Err(_err) = self.transport.send_recv_buf(command.duration(), &mut buf) {
+            if let Err(_err) = self.transport.send_recv_buf(delay, &mut buf) {
                 if retry == retries {
                     break;
                 } else {

--- a/src/ecc.rs
+++ b/src/ecc.rs
@@ -165,15 +165,11 @@ impl Ecc {
         sleep: bool,
         retries: u8,
     ) -> Result<Bytes> {
-        let mut buf = BytesMut::new();
-        match self.transport.protocol{
-            TransportProtocol::I2c => { 
-                buf = BytesMut::with_capacity(ATCA_I2C_CMD_SIZE_MAX as usize);
-            }
-            TransportProtocol::Swi => {
-                buf = BytesMut::with_capacity(ATCA_SWI_CMD_SIZE_MAX as usize);
-            }
-        }
+
+        let mut buf = match self.transport.protocol {
+            TransportProtocol::I2c => BytesMut::with_capacity(ATCA_I2C_CMD_SIZE_MAX as usize),
+            TransportProtocol::Swi => BytesMut::with_capacity(ATCA_SWI_CMD_SIZE_MAX as usize),
+        };
 
         for retry in 0..retries {
             let response = self.transport.send_wake();

--- a/src/ecc.rs
+++ b/src/ecc.rs
@@ -1,7 +1,4 @@
-use crate::constants::{
-    ATCA_SWI_CMD_SIZE_MAX, ATCA_I2C_CMD_SIZE_MAX, ATCA_I2C_COMMAND_FLAG,
-    ATCA_SWI_COMMAND_FLAG, WAKE_DELAY
-};
+use crate::constants::{ ATCA_CMD_SIZE_MAX, ATCA_I2C_COMMAND_FLAG, ATCA_SWI_COMMAND_FLAG, WAKE_DELAY };
 use crate::transport::{EccTransport, TransportProtocol};
 use crate::{
     command::{EccCommand, EccResponse},
@@ -166,17 +163,10 @@ impl Ecc {
         retries: u8,
     ) -> Result<Bytes> {
 
-        let mut buf = match self.transport.protocol {
-            TransportProtocol::I2c => BytesMut::with_capacity(ATCA_I2C_CMD_SIZE_MAX as usize),
-            TransportProtocol::Swi => BytesMut::with_capacity(ATCA_SWI_CMD_SIZE_MAX as usize),
-        };
+        let mut buf = BytesMut::with_capacity(ATCA_CMD_SIZE_MAX as usize);
 
         for retry in 0..retries {
             let response = self.transport.send_wake();
-            
-            if cfg!(feature = "i2c"){           //SWI has wake delay built into interaction
-                thread::sleep(WAKE_DELAY);
-            }
 
             match response {
                 Ok(_) => (),

--- a/src/transport.rs
+++ b/src/transport.rs
@@ -30,7 +30,7 @@ pub(crate) struct EccTransport {
 impl EccTransport {
     pub fn from_path(path: &str, address: u16) -> Result<Self> {
         
-        if path.contains("/dev/tty"){
+        if path.starts_with("/dev/tty"){
             let swi_port = serialport::new(path, SWI_DEFAULT_BAUDRATE)
             .data_bits(serialport::DataBits::Seven)
             .parity(serialport::Parity::None)
@@ -48,7 +48,7 @@ impl EccTransport {
                 protocol: TransportProtocol::Swi
             })    
         }
-        else if path.contains("/dev/i2c") {
+        else if path.starts_with("/dev/i2c") {
             let mut i2c = I2c::from_path(path)?;
             i2c.smbus_set_slave_address(address, false)?;
             


### PR DESCRIPTION
This changes adds runtime selection of the interface with the ECC chip. This is done by having the i2c and uart ports as optional items in the transport struct which get populated based on the device path passed in on initialization. After the initalization, match statements are used on each method to determine which protocol to use.

Additionally, optimizations were made in terms of improving some command durations, and altering how the SWI receives packets from the chip.